### PR TITLE
Support PlantUML in Markdown

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -2970,7 +2970,15 @@ QCString Markdown::processQuotations(const QCString &s,int refIndent)
     {
       if (isFencedCodeBlock(data+pi,size-pi,currentIndent,lang,blockStart,blockEnd,blockOffset))
       {
-        writeFencedCodeBlock(data+pi,lang.data(),blockStart,blockEnd);
+        if (lang=="plantuml")
+        {
+          int cmdStart = pi+blockStart+1;
+          processSpecialCommand(data+cmdStart,cmdStart,size-cmdStart);
+        }
+        else
+        {
+          writeFencedCodeBlock(data+pi,lang.data(),blockStart,blockEnd);
+        }
         i=pi+blockOffset;
         pi=-1;
         end=i+1;


### PR DESCRIPTION
GitHub and GitLab render PlantUML diagrams in Markdown documents inline and don't display the code. This PR makes Doxygen behave in the same way.
This PR is an adaption of @ArjanKn's pull request #6953 to compile with the currend HEAD.